### PR TITLE
Generator cannot return using "return"

### DIFF
--- a/lib/AcmeClient.php
+++ b/lib/AcmeClient.php
@@ -144,7 +144,7 @@ class AcmeClient {
             throw new AcmeException("GET request to {$uri} failed.", null, $e);
         }
 
-        return $response;
+        yield $response;
     }
 
     public function post($resource, array $payload) {
@@ -196,7 +196,7 @@ class AcmeClient {
             throw new AcmeException("POST request to {$uri} failed.", null, $e);
         }
 
-        return $response;
+        yield $response;
     }
 
     private function saveNonce(Response $response) {

--- a/lib/AcmeService.php
+++ b/lib/AcmeService.php
@@ -180,7 +180,8 @@ class AcmeService {
         ]));
 
         if ($response->getStatus() === 202) {
-            return json_decode($response->getBody());
+            yield json_decode($response->getBody());
+            return;
         }
 
         throw $this->generateException($response);


### PR DESCRIPTION
I came across the following error, when switching from my port to your PHP 5.5  (nearly) compatible library. 

```Fatal error: Generators cannot return values using "return" in /usr/local/directadmin/plugins/da-letsencrypt/vendor/kelunik/acme/lib/AcmeService.php on line 183```

The RFC for this feature was recently accepted and implemented in PHP 7.0, see [here](https://wiki.php.net/rfc/generator-return-expressions).