### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
         "psr-4": {
             "Kelunik\\Acme\\": "lib"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.2-dev"
+        }
     }
 }


### PR DESCRIPTION
So people can easily require the correct version (`0.2@dev` eg.)