### PR TITLE
Prevent a misleading message due to programming mistake

### DIFF
--- a/lib/AcmeService.php
+++ b/lib/AcmeService.php
@@ -234,6 +234,10 @@ class AcmeService {
     }
 
     private function doRequestCertificate(KeyPair $keyPair, array $domains) {
+        if (empty($domains)) {
+            throw new AcmeException('$domains array is empty!');
+        }
+        
         if (!$privateKey = openssl_pkey_get_private($keyPair->getPrivate())) {
             // TODO: Improve error message
             throw new AcmeException("Couldn't use private key.");


### PR DESCRIPTION
If you accidentally pass empty $domains array, you'd get:
```
openssl_csr_new(): Error loading request_extensions_section section v3_req of /tmp/acme_openssl_config_avfbox
```

Let's catch that with a clear Exception.