### PR TITLE
Dns verification

### DIFF
--- a/test/Dns01VerificationTest.php
+++ b/test/Dns01VerificationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kelunik\Acme;
+
+class Dns01VerificationTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * @test
+     */
+    public function failsOnDnsNotFound() {
+        \Amp\run(function() {
+            $keyPair = (new OpenSSLKeyGenerator())->generate();
+            $client = new AcmeClient("https://acme-staging.api.letsencrypt.org/directory", $keyPair);
+            $service = new AcmeService($client, $keyPair);
+
+            /** @var Response $payloadResponse */
+            $payload = "foobar";
+
+            try {
+            	yield $service->verifyDns01Challenge("google.com", $payload);
+            } catch (AcmeException $e) {
+            	$this->assertEquals($e->getMessage(), "selfVerify failed, no DNS record found for expected domain: _acme-challenge.google.com");
+            } finally {
+				\Amp\stop();
+			}
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function failsOnWrongPayload() {
+    	\Amp\run(function() {
+            $keyPair = (new OpenSSLKeyGenerator())->generate();
+            $client = new AcmeClient("https://acme-staging.api.letsencrypt.org/directory", $keyPair);
+            $service = new AcmeService($client, $keyPair);
+
+            /** @var Response $payloadResponse */
+            $payload = "foobar";
+
+            try {
+            	yield $service->verifyDns01Challenge("kevin-test.kf.porticor.net", $payload);
+            } catch (AcmeException $e) {
+            	$this->assertEquals($e->getMessage(), "selfVerify failed, please check DNS record under _acme-challenge.kevin-test.kf.porticor.net.");
+            } finally {
+				\Amp\stop();
+			}
+        });
+    }
+}


### PR DESCRIPTION
The DNS-01 challenge requires a TXT record under a validation domain name with “_acme-challenge.” prepended to the domain name being validated (_acme-challenge.example.com). I attempted to use \Amp\Dns\query for DNS record lookup, but was receiving an invalid host name error with this validation domain (because of the leading underscore). Should I open an issue in the \Amp\Dns repo or is my use of dns_get_record($uri) ok here?

This method simply looks up the TXT record under the validation domain and ensures the value attached to the TXT record matches the expected payload for DNS-01 validation.