### PR TITLE
Fixed badNonce error catching.

### DIFF
--- a/lib/AcmeClient.php
+++ b/lib/AcmeClient.php
@@ -289,7 +289,7 @@ class AcmeClient {
                 if ($response->getStatus() === 400) {
                     $info = json_decode($response->getBody());
 
-                    if ($info && isset($info->type) && $info->type === "urn:acme:badNonce") {
+                    if ($info && isset($info->type) && ($info->type === "urn:acme:badNonce" or $info->type === "urn:acme:error:badNonce")) {
                         continue;
                     }
                 }


### PR DESCRIPTION
badNonce error checking was checking for the wrong response "type" and therefore never auto-retried on failed POSTs due to bad nonces. Let's Encrypt server responds to bad nonces with the response type set to "urn:acme:**error**:badNonce", not "urn:acme:badNonce". See example response output bellow:

     {"type":"urn:acme:error:badNonce","detail":"JWS has invalid anti-replay nonce 8uktmunjoGZRPWMul0WUyudOiScKW5BSrEj3T2UxbjA","status":400}

Also see line 22 of the Let's Encrypt acme "messages.py" implementation: https://github.com/letsencrypt/letsencrypt/blob/master/acme/acme/messages.py

I left in the check for "urn:acme:badNonce" because this is the ACME error code specified in the IETF ACME draft.