### PR TITLE
Support for generating EC keys

### DIFF
--- a/lib/KeyGenerator.php
+++ b/lib/KeyGenerator.php
@@ -16,12 +16,13 @@ namespace Kelunik\Acme;
  * @package Kelunik\Acme
  */
 interface KeyGenerator {
-    /**
-     * Generates a new key pair with the given length in bits.
-     *
-     * @api
-     * @param int $bits length of the key
-     * @return KeyPair generated key pair
-     */
-    public function generate($bits);
+  /**
+   * Generates a new key pair with the given length in bits or an Eliptic curve.
+   *
+   * @api
+   * @param int|string $bits length of the key or the Eliptic curve name
+   * @param $key_type int type of the key
+   * @return KeyPair generated key pair
+   */
+  public function generate($bits, $key_type);
 }


### PR DESCRIPTION
Hi Niklas,
I have been using acme-client for a long time, and it is working really great! Since PHP 7.1 is released with EC key support (#14), I tried to add support. 

I had to make some PHPDoc changes to make the `KeyGenerator` explaining that it can be used with other types of keys as well. In the `OpenSSLKeyGenerator`, it now supports `OPENSSL_KEYTYPE_RSA` and `OPENSSL_KEYTYPE_EC`, with different validations for each type. 

For some reason, the EC key generation requires the `$key_options['private_key_bits']` key to be set and larger than 384, hence the `$key_options['private_key_bits'] = 2048;` line in the EC switch case. 

I tried running the tests myself (without a luck). I'd be grateful if you could provide an insight. I tested the key generation part by hand, and it did work well. 

```
$gen = new \Kelunik\Acme\OpenSSLKeyGenerator();
$pair = $gen->generate('prime256v1', OPENSSL_KEYTYPE_EC);
```

Thank you very much.