### PR TITLE
Make OpenSSLCSRGenerator return a CSR string

### DIFF
--- a/test/OpenSSLCSRGeneratorTest.php
+++ b/test/OpenSSLCSRGeneratorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Kelunik\Acme;
+
+use Kelunik\Acme\CSR\OpenSSLCSRGenerator;
+
+class OpenSSLCSRGeneratorTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var OpenSSLKeyGenerator
+     */
+    private $keyGenerator;
+
+    /**
+     * @var OpenSSLCSRGenerator
+     */
+    private $csrGenerator;
+
+    public function setUp() {
+        $this->csrGenerator = new OpenSSLCSRGenerator();
+        $this->keyGenerator = new OpenSSLKeyGenerator();
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function failsWithInvalidConfig()
+    {
+        new OpenSSLCSRGenerator(["must_staple" => "invalid"]);
+    }
+
+    /**
+     * @test
+     * @expectedException \Kelunik\Acme\AcmeException
+     */
+    public function failsWithInvalidKey()
+    {
+        \Amp\wait(\Amp\resolve($this->csrGenerator->generate(new KeyPair("foo", "bar"), ["example.com"])));
+    }
+
+    /**
+     * @test
+     * @expectedException \Kelunik\Acme\AcmeException
+     */
+    public function failsWithNoDomains()
+    {
+        \Amp\wait(\Amp\resolve($this->csrGenerator->generate($this->keyGenerator->generate(), [])));
+    }
+
+    /**
+     * @test
+     */
+    public function succeedsOtherwise()
+    {
+        $csr = \Amp\wait(\Amp\resolve($this->csrGenerator->generate($this->keyGenerator->generate(), ["example.com"])));
+
+        $this->assertInternalType("string", $csr);
+    }
+}


### PR DESCRIPTION
I added a test which might need some `Amp` cleanup.

I don't know how to trigger the `openssl_csr_new` error so I didn't write a test case for it.