### PR TITLE
Reset nonces after a nonce error

### DIFF
--- a/lib/AcmeClient.php
+++ b/lib/AcmeClient.php
@@ -311,6 +311,7 @@ final class AcmeClient {
                         $info = json_decode($body);
 
                         if (!empty($info->type) && ($info->type === 'urn:acme:badNonce' || $info->type === 'urn:acme:error:badNonce')) {
+                            $this->nonces = [];
                             continue;
                         }
                     } else if ($statusCode === 429) {


### PR DESCRIPTION
When processing renewal batches of approximately 200 certificates, after some point the nonces contained in the internal array, that fulfill the objective of reutilization, start to be incorrect, and every request made after that point will result in a nonce error. 

The fix I found (and tested in production) is to discard nonces once a `urn:acme:error:badNonce` occurs, so the client avoids this state of invalid nonces and can continue to work normally.