### PR TITLE
Update for AMP v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "amphp/amp": "^3",

--- a/composer.json
+++ b/composer.json
@@ -26,21 +26,23 @@
             "src/Protocol/functions.php"
         ]
     },
+    "prefer-stable": true,
+    "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "amphp/amp": "^2",
-        "amphp/http-client": "^4",
+        "amphp/amp": "^3",
+        "amphp/http-client": "^5",
         "sabre/uri": "^1",
         "psr/log": "^1 || ^2 || ^3",
         "kelunik/certificate": "^1.1",
-        "amphp/file": "^2.0",
+        "amphp/file": "^3",
         "beberlei/assert": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8 || ^9",
-        "amphp/phpunit-util": "^1.0",
+        "amphp/phpunit-util": "^3.0",
         "amphp/php-cs-fixer-config": "dev-master"
     },
     "extra": {

--- a/src/AcmeClient.php
+++ b/src/AcmeClient.php
@@ -210,7 +210,7 @@ final class AcmeClient
                      * Hit rate limit.
                      * @{link} https://letsencrypt.org/docs/rate-limits/
                      */
-                    delay(1000);
+                    delay(1);
                     continue;
                 }
             } catch (Throwable $e) {

--- a/src/AcmeService.php
+++ b/src/AcmeService.php
@@ -216,7 +216,7 @@ class AcmeService
                 break;
             }
 
-            delay(3000);
+            delay(3);
         } while (true);
     }
 
@@ -245,7 +245,7 @@ class AcmeService
                 break;
             }
 
-            delay(3000);
+            delay(3);
         } while (true);
     }
 
@@ -274,7 +274,7 @@ class AcmeService
                 break;
             }
 
-            delay(3000);
+            delay(3);
         } while (true);
     }
 

--- a/src/AcmeService.php
+++ b/src/AcmeService.php
@@ -52,48 +52,42 @@ class AcmeService
      * @param string $email e-mail address for contact
      * @param bool   $agreement
      *
-     * @return Promise<Account>
+     * @return Account
      *
      * @see https://datatracker.ietf.org/doc/html/rfc8555#section-7.3
      */
-    public function register(string $email, bool $agreement = false): Promise
+    public function register(string $email, bool $agreement = false): Account
     {
-        return call(function () use ($email, $agreement) {
-            $this->logger->info('Creating new account with email ' . $email);
+        $this->logger->info('Creating new account with email ' . $email);
 
-            /** @var Response $response */
-            $response = yield $this->client->post(AcmeResource::NEW_ACCOUNT, [
-                'termsOfServiceAgreed' => $agreement,
-                'contact' => [
-                    "mailto:{$email}",
-                ],
-            ]);
+        $response = $this->client->post(AcmeResource::NEW_ACCOUNT, [
+            'termsOfServiceAgreed' => $agreement,
+            'contact' => [
+                "mailto:{$email}",
+            ],
+        ]);
 
-            if (\in_array($response->getStatus(), [200, 201], true)) {
-                return Account::fromResponse($response->getHeader('location'), yield $response->getBody()->buffer());
-            }
+        if (\in_array($response->getStatus(), [200, 201], true)) {
+            return Account::fromResponse($response->getHeader('location'), $response->getBody()->buffer());
+        }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**
      * Retrieves existing order using the order's location URL.
      */
-    public function getOrder(UriInterface $url): Promise
+    public function getOrder(UriInterface $url): Order
     {
-        return call(function () use ($url) {
-            $this->logger->info('Retrieving order ' . $url);
+        $this->logger->info('Retrieving order ' . $url);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, null);
+        $response = $this->client->post($url, null);
 
-            if ($response->getStatus() === 200) {
-                return Order::fromResponse($url, yield $response->getBody()->buffer());
-            }
+        if ($response->getStatus() === 200) {
+            return Order::fromResponse($url, $response->getBody()->buffer());
+        }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**
@@ -103,41 +97,38 @@ class AcmeService
      * @param \DateTimeInterface|null $notBefore The requested value of the notBefore field in the certificate
      * @param \DateTimeInterface|null $notAfter The requested value of the notAfter field in the certificate
      *
-     * @return Promise<Order>
+     * @return Order
      */
     public function newOrder(
         array $domainNames,
         ?\DateTimeInterface $notBefore = null,
         ?\DateTimeInterface $notAfter = null
-    ): Promise {
-        return call(function () use ($domainNames, $notBefore, $notAfter) {
-            $this->logger->info('Creating new order for ' . \implode(', ', $domainNames));
+    ): Order {
+        $this->logger->info('Creating new order for ' . \implode(', ', $domainNames));
 
-            $request = [
-                'identifiers' => [],
-            ];
+        $request = [
+            'identifiers' => [],
+        ];
 
-            foreach ($domainNames as $domainName) {
-                $request['identifiers'][] = ['type' => 'dns', 'value' => $domainName];
-            }
+        foreach ($domainNames as $domainName) {
+            $request['identifiers'][] = ['type' => 'dns', 'value' => $domainName];
+        }
 
-            if ($notBefore) {
-                $request['notBefore'] = formatDate($notBefore);
-            }
+        if ($notBefore) {
+            $request['notBefore'] = formatDate($notBefore);
+        }
 
-            if ($notAfter) {
-                $request['notAfter'] = formatDate($notAfter);
-            }
+        if ($notAfter) {
+            $request['notAfter'] = formatDate($notAfter);
+        }
 
-            /** @var Response $response */
-            $response = yield $this->client->post(AcmeResource::NEW_ORDER, $request);
+        $response = $this->client->post(AcmeResource::NEW_ORDER, $request);
 
-            if ($response->getStatus() === 201) {
-                return Order::fromResponse($response->getHeader('location'), yield $response->getBody()->buffer());
-            }
+        if ($response->getStatus() === 201) {
+            return Order::fromResponse($response->getHeader('location'), $response->getBody()->buffer());
+        }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**
@@ -145,22 +136,19 @@ class AcmeService
      *
      * @param UriInterface $url URI of the challenge
      *
-     * @return Promise<Challenge>
+     * @return Challenge
      */
-    public function finalizeChallenge(UriInterface $url): Promise
+    public function finalizeChallenge(UriInterface $url): Challenge
     {
-        return call(function () use ($url) {
-            $this->logger->info('Finalizing challenge ' . $url);
+        $this->logger->info('Finalizing challenge ' . $url);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, []);
+        $response = $this->client->post($url, []);
 
-            try {
-                return Challenge::fromResponse(yield $response->getBody()->buffer());
-            } catch (\Throwable $_) {
-                throw $this->generateException($response, yield $response->getBody()->buffer());
-            }
-        });
+        try {
+            return Challenge::fromResponse($response->getBody()->buffer());
+        } catch (\Throwable $_) {
+            throw $this->generateException($response, $response->getBody()->buffer());
+        }
     }
 
     /**
@@ -168,22 +156,19 @@ class AcmeService
      *
      * @param UriInterface $url
      *
-     * @return Promise<Authorization>
+     * @return Authorization
      */
-    public function getAuthorization(UriInterface $url): Promise
+    public function getAuthorization(UriInterface $url): Authorization
     {
-        return call(function () use ($url) {
-            $this->logger->info('Retrieving authorization ' . $url);
+        $this->logger->info('Retrieving authorization ' . $url);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, null);
+        $response = $this->client->post($url, null);
 
-            try {
-                return Authorization::fromResponse($url, yield $response->getBody()->buffer());
-            } catch (\Throwable $_) {
-                throw $this->generateException($response, yield $response->getBody()->buffer());
-            }
-        });
+        try {
+            return Authorization::fromResponse($url, $response->getBody()->buffer());
+        } catch (\Throwable $_) {
+            throw $this->generateException($response, $response->getBody()->buffer());
+        }
     }
 
     /**
@@ -191,22 +176,19 @@ class AcmeService
      *
      * @param UriInterface $url
      *
-     * @return Promise<Challenge>
+     * @return Challenge
      */
-    public function getChallenge(UriInterface $url): Promise
+    public function getChallenge(UriInterface $url): Challenge
     {
-        return call(function () use ($url) {
-            $this->logger->info('Retrieving challenge ' . $url);
+        $this->logger->info('Retrieving challenge ' . $url);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, null);
+        $response = $this->client->post($url, null);
 
-            try {
-                return Challenge::fromResponse(yield $response->getBody()->buffer());
-            } catch (\Throwable $_) {
-                throw $this->generateException($response, yield $response->getBody()->buffer());
-            }
-        });
+        try {
+            return Challenge::fromResponse($response->getBody()->buffer());
+        } catch (\Throwable $_) {
+            throw $this->generateException($response, $response->getBody()->buffer());
+        }
     }
 
     /**
@@ -214,31 +196,28 @@ class AcmeService
      *
      * @param UriInterface $url URI of the authorization
      *
-     * @return Promise<void>
+     * @return void
      */
-    public function pollForAuthorization(UriInterface $url): Promise
+    public function pollForAuthorization(UriInterface $url): void
     {
-        return call(function () use ($url) {
-            $this->logger->info('Polling for authorization ' . $url);
+        $this->logger->info('Polling for authorization ' . $url);
 
-            do {
-                /** @var Authorization $authorization */
-                $authorization = yield $this->getAuthorization($url);
+        do {
+            $authorization = $this->getAuthorization($url);
 
-                $this->logger->info('Retrieved authorization ' . $url . ': ' . $authorization->getStatus());
+            $this->logger->info('Retrieved authorization ' . $url . ': ' . $authorization->getStatus());
 
-                if ($authorization->getStatus() === ChallengeStatus::INVALID) {
-                    // TODO Use Challenge->getError
-                    throw new AcmeException('Authorization marked as invalid.');
-                }
+            if ($authorization->getStatus() === ChallengeStatus::INVALID) {
+                // TODO Use Challenge->getError
+                throw new AcmeException('Authorization marked as invalid.');
+            }
 
-                if ($authorization->getStatus() === ChallengeStatus::VALID) {
-                    break;
-                }
+            if ($authorization->getStatus() === ChallengeStatus::VALID) {
+                break;
+            }
 
-                yield delay(3000);
-            } while (true);
-        });
+            delay(3000);
+        } while (true);
     }
 
     /**
@@ -246,31 +225,28 @@ class AcmeService
      *
      * @param UriInterface $url URI of the order
      *
-     * @return Promise<void>
+     * @return void
      */
-    public function pollForOrderReady(UriInterface $url): Promise
+    public function pollForOrderReady(UriInterface $url): void
     {
-        return call(function () use ($url) {
-            $this->logger->info('Polling for order to be ready ' . $url);
+        $this->logger->info('Polling for order to be ready ' . $url);
 
-            do {
-                /** @var Order $order */
-                $order = yield $this->getOrder($url);
+        do {
+            $order = $this->getOrder($url);
 
-                $this->logger->info('Retrieved order ' . $url . ': ' . $order->getStatus());
+            $this->logger->info('Retrieved order ' . $url . ': ' . $order->getStatus());
 
-                if ($order->getStatus() === OrderStatus::INVALID) {
-                    // TODO Use Challenge->getError
-                    throw new AcmeException('Order marked as invalid.');
-                }
+            if ($order->getStatus() === OrderStatus::INVALID) {
+                // TODO Use Challenge->getError
+                throw new AcmeException('Order marked as invalid.');
+            }
 
-                if ($order->getStatus() === OrderStatus::READY) {
-                    break;
-                }
+            if ($order->getStatus() === OrderStatus::READY) {
+                break;
+            }
 
-                yield delay(3000);
-            } while (true);
-        });
+            delay(3000);
+        } while (true);
     }
 
     /**
@@ -278,31 +254,28 @@ class AcmeService
      *
      * @param UriInterface $url URI of the order
      *
-     * @return Promise<void>
+     * @return void
      */
-    public function pollForOrderValid(UriInterface $url): Promise
+    public function pollForOrderValid(UriInterface $url): void
     {
-        return call(function () use ($url) {
-            $this->logger->info('Polling for order to be valid ' . $url);
+        $this->logger->info('Polling for order to be valid ' . $url);
 
-            do {
-                /** @var Order $order */
-                $order = yield $this->getOrder($url);
+        do {
+            $order = $this->getOrder($url);
 
-                $this->logger->info('Retrieved order ' . $url . ': ' . $order->getStatus());
+            $this->logger->info('Retrieved order ' . $url . ': ' . $order->getStatus());
 
-                if ($order->getStatus() === OrderStatus::INVALID) {
-                    // TODO Use Challenge->getError
-                    throw new AcmeException('Order marked as invalid.');
-                }
+            if ($order->getStatus() === OrderStatus::INVALID) {
+                // TODO Use Challenge->getError
+                throw new AcmeException('Order marked as invalid.');
+            }
 
-                if ($order->getStatus() === OrderStatus::VALID) {
-                    break;
-                }
+            if ($order->getStatus() === OrderStatus::VALID) {
+                break;
+            }
 
-                yield delay(3000);
-            } while (true);
-        });
+            delay(3000);
+        } while (true);
     }
 
     /**
@@ -311,41 +284,39 @@ class AcmeService
      * @param UriInterface $url
      * @param string       $csr certificate signing request
      *
-     * @return Promise<Order>
+     * @return Order
      */
-    public function finalizeOrder(UriInterface $url, string $csr): Promise
+    public function finalizeOrder(UriInterface $url, string $csr): Order
     {
-        return call(function () use ($url, $csr) {
-            $this->logger->info('Finalizing order ' . $url);
+        $this->logger->info('Finalizing order ' . $url);
 
-            $begin = 'REQUEST-----';
-            $end = '----END';
+        $begin = 'REQUEST-----';
+        $end = '----END';
 
-            $beginPos = \strpos($csr, $begin);
-            if ($beginPos === false) {
-                throw new InvalidArgumentException("Invalid CSR, maybe not in PEM format?\n{$csr}");
-            }
+        $beginPos = \strpos($csr, $begin);
+        if ($beginPos === false) {
+            throw new InvalidArgumentException("Invalid CSR, maybe not in PEM format?\n{$csr}");
+        }
 
-            $csr = \substr($csr, $beginPos + \strlen($begin));
+        $csr = \substr($csr, $beginPos + \strlen($begin));
 
-            $endPos = \strpos($csr, $end);
-            if ($endPos === false) {
-                throw new InvalidArgumentException("Invalid CSR, maybe not in PEM format?\n{$csr}");
-            }
+        $endPos = \strpos($csr, $end);
+        if ($endPos === false) {
+            throw new InvalidArgumentException("Invalid CSR, maybe not in PEM format?\n{$csr}");
+        }
 
-            $csr = \substr($csr, 0, $endPos);
+        $csr = \substr($csr, 0, $endPos);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, [
-                'csr' => base64UrlEncode(\base64_decode($csr)),
-            ]);
+        /** @var Response $response */
+        $response = $this->client->post($url, [
+            'csr' => base64UrlEncode(\base64_decode($csr)),
+        ]);
 
-            if ($response->getStatus() === 200) {
-                return Order::fromResponse($response->getHeader('location'), yield $response->getBody()->buffer());
-            }
+        if ($response->getStatus() === 200) {
+            return Order::fromResponse($response->getHeader('location'), $response->getBody()->buffer());
+        }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**
@@ -353,36 +324,33 @@ class AcmeService
      *
      * @param UriInterface $url URI of the certificate
      *
-     * @return Promise Complete certificate chain as array of PEM encoded certificates
+     * @return Certificate[] Complete certificate chain as array of PEM encoded certificates
      */
-    public function downloadCertificates(UriInterface $url): Promise
+    public function downloadCertificates(UriInterface $url): array
     {
-        return call(function () use ($url) {
-            $this->logger->info('Downloading certificate ' . $url);
+        $this->logger->info('Downloading certificate ' . $url);
 
-            /** @var Response $response */
-            $response = yield $this->client->post($url, null);
+        $response = $this->client->post($url, null);
 
-            if ($response->getStatus() === 200) {
-                $certificateChain = yield $response->getBody()->buffer();
-                $certificates = [];
+        if ($response->getStatus() === 200) {
+            $certificateChain = $response->getBody()->buffer();
+            $certificates = [];
 
-                while (\preg_match(
-                    '(-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----)si',
-                    $certificateChain,
-                    $match
-                )) {
-                    $certificateChain = \str_replace($match[0], '', $certificateChain);
-                    $certificate = Certificate::derToPem(Certificate::pemToDer($match[0]));
+            while (\preg_match(
+                '(-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----)si',
+                $certificateChain,
+                $match
+            )) {
+                $certificateChain = \str_replace($match[0], '', $certificateChain);
+                $certificate = Certificate::derToPem(Certificate::pemToDer($match[0]));
 
-                    $certificates[] = $certificate;
-                }
-
-                return $certificates;
+                $certificates[] = $certificate;
             }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+            return $certificates;
+        }
+
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**
@@ -390,24 +358,21 @@ class AcmeService
      *
      * @param string $pem PEM encoded certificate
      *
-     * @return Promise<void>
+     * @return void
      */
-    public function revokeCertificate(string $pem): Promise
+    public function revokeCertificate(string $pem): void
     {
-        return call(function () use ($pem) {
-            $this->logger->info('Revoking certificate ' . $pem);
+        $this->logger->info('Revoking certificate ' . $pem);
 
-            /** @var Response $response */
-            $response = yield $this->client->post(AcmeResource::REVOKE_CERTIFICATE, [
-                'certificate' => base64UrlEncode(Certificate::pemToDer($pem)),
-            ]);
+        $response = $this->client->post(AcmeResource::REVOKE_CERTIFICATE, [
+            'certificate' => base64UrlEncode(Certificate::pemToDer($pem)),
+        ]);
 
-            if ($response->getStatus() === 200) {
-                return;
-            }
+        if ($response->getStatus() === 200) {
+            return;
+        }
 
-            throw $this->generateException($response, yield $response->getBody()->buffer());
-        });
+        throw $this->generateException($response, $response->getBody()->buffer());
     }
 
     /**

--- a/src/Csr/CsrGenerator.php
+++ b/src/Csr/CsrGenerator.php
@@ -26,8 +26,8 @@ interface CsrGenerator
      * @param PrivateKey $key Key to use for signing.
      * @param array      $domains List of domain names.
      *
-     * @return Promise Resolves to a string (PEM encoded CSR).
+     * @return string Resolves to a string (PEM encoded CSR).
      * @throws AcmeException If CSR generation fails.
      */
-    public function generateCsr(PrivateKey $key, array $domains): Promise;
+    public function generateCsr(PrivateKey $key, array $domains): string;
 }

--- a/src/Verifiers/Http01.php
+++ b/src/Verifiers/Http01.php
@@ -52,24 +52,20 @@ final class Http01
      * @param string $token Challenge token.
      * @param string $expectedPayload Expected payload.
      *
-     * @return Promise Resolves successfully if the challenge has been successfully verified, otherwise fails.
+     * @return void Resolves successfully if the challenge has been successfully verified, otherwise fails.
      * @throws AcmeException If the challenge could not be verified.
      * @api
      */
-    public function verifyChallenge(string $domain, string $token, string $expectedPayload): Promise
+    public function verifyChallenge(string $domain, string $token, string $expectedPayload): void
     {
-        return call(function () use ($domain, $token, $expectedPayload) {
-            $uri = "http://{$domain}/.well-known/acme-challenge/{$token}";
+        $uri = "http://{$domain}/.well-known/acme-challenge/{$token}";
 
-            /** @var Response $response */
-            $response = yield $this->httpClient->request(new Request($uri));
+        $response = $this->httpClient->request(new Request($uri));
 
-            /** @var string $body */
-            $body = yield $response->getBody()->buffer();
+        $body = $response->getBody()->buffer();
 
-            if (\rtrim($expectedPayload) !== \rtrim($body)) {
-                throw new AcmeException("Verification failed, please check the response body for '{$uri}'. It contains '{$body}' but '{$expectedPayload}' was expected.");
-            }
-        });
+        if (\rtrim($expectedPayload) !== \rtrim($body)) {
+            throw new AcmeException("Verification failed, please check the response body for '{$uri}'. It contains '{$body}' but '{$expectedPayload}' was expected.");
+        }
     }
 }

--- a/test/AcmeServiceTest.php
+++ b/test/AcmeServiceTest.php
@@ -40,26 +40,26 @@ class AcmeServiceTest extends AsyncTestCase
     /**
      * @test
      */
-    public function registerNotAgreeTOS(): \Generator
+    public function registerNotAgreeTOS(): void
     {
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage('Provided account did not agree to the terms of service');
 
-        yield $this->service->register('me@example.com');
+        $this->service->register('me@example.com');
     }
 
     /**
      * @test
      */
-    public function registerAndReRegisterGivesSameLocation(): \Generator
+    public function registerAndReRegisterGivesSameLocation(): void
     {
         /** @var Account $account */
-        $account = yield $this->service->register('me@example.com', true);
+        $account = $this->service->register('me@example.com', true);
         $this->assertSame('mailto:me@example.com', (string) $account->getContacts()[0]);
         $this->assertNotNull($l1 = (string) $account->getUrl());
 
         /** @var Account $account */
-        $account = yield $this->service->register('me@example.com', true);
+        $account = $this->service->register('me@example.com', true);
         $this->assertSame('mailto:me@example.com', (string) $account->getContacts()[0]);
         $this->assertNotNull($l2 = (string) $account->getUrl());
 

--- a/test/ConnectTest.php
+++ b/test/ConnectTest.php
@@ -16,15 +16,14 @@ class ConnectTest extends AsyncTestCase
      *
      * @dataProvider provideCryptoConnectArgs
      */
-    public function testCryptoConnect($uri)
+    public function testCryptoConnect($uri): void
     {
         $this->expectNotToPerformAssertions();
 
         $context = (new ConnectContext)->withTlsContext(new ClientTlsContext(\parse_url($uri, \PHP_URL_HOST)));
 
-        /** @var EncryptableSocket $sock */
-        $sock = yield connect($uri, $context);
-        yield $sock->setupTls();
+        $sock = connect($uri, $context);
+        $sock->setupTls();
     }
 
     public function provideCryptoConnectArgs(): iterable

--- a/test/Dns01VerificationTest.php
+++ b/test/Dns01VerificationTest.php
@@ -30,67 +30,67 @@ class Dns01VerificationTest extends AsyncTestCase
     /**
      * @test
      */
-    public function failsOnDnsNotFound(): \Generator
+    public function failsOnDnsNotFound(): void
     {
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage('Verification failed, no TXT record found for \'_acme-challenge.example.com\'.');
 
-        $this->resolver->method("query")->willReturn(new Failure(new NoRecordException));
-        yield $this->verifier->verifyChallenge("example.com", "foobar");
+        $this->resolver->method("query")->willThrowException(new NoRecordException);
+        $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
     /**
      * @test
      */
-    public function failsOnGeneralDnsIssue(): \Generator
+    public function failsOnGeneralDnsIssue(): void
     {
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage('Verification failed, couldn\'t query TXT record of \'_acme-challenge.example.com\'');
 
-        $this->resolver->method("query")->willReturn(new Failure(new DnsException));
-        yield $this->verifier->verifyChallenge("example.com", "foobar");
+        $this->resolver->method("query")->willThrowException(new DnsException);
+        $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
     /**
      * @test
      */
-    public function failsOnWrongPayload(): \Generator
+    public function failsOnWrongPayload(): void
     {
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage("Verification failed, please check DNS record for '_acme-challenge.example.com'.");
 
-        $this->resolver->method("query")->willReturn(new Success([new Record("xyz", Record::TXT, 300)]));
-        yield $this->verifier->verifyChallenge("example.com", "foobar");
+        $this->resolver->method("query")->willReturn([new Record("xyz", Record::TXT, 300)]);
+        $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
     /**
      * @test
      */
-    public function succeedsOnRightPayload(): \Generator
+    public function succeedsOnRightPayload(): void
     {
         $this->expectNotToPerformAssertions();
 
-        $this->resolver->method("query")->willReturn(new Success([new Record("foobar", Record::TXT, 300)]));
-        yield $this->verifier->verifyChallenge("example.com", "foobar");
+        $this->resolver->method("query")->willReturn([new Record("foobar", Record::TXT, 300)]);
+        $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
     /**
      * @test
      */
-    public function failsWithDomainNotString(): \Generator
+    public function failsWithDomainNotString(): void
     {
         $this->expectException(\TypeError::class);
 
-        yield $this->verifier->verifyChallenge(null, "");
+        $this->verifier->verifyChallenge(null, "");
     }
 
     /**
      * @test
      */
-    public function failsWithPayloadNotString(): \Generator
+    public function failsWithPayloadNotString(): void
     {
         $this->expectException(\TypeError::class);
 
-        yield $this->verifier->verifyChallenge("example.com", null);
+        $this->verifier->verifyChallenge("example.com", null);
     }
 }

--- a/test/Http01VerificationTest.php
+++ b/test/Http01VerificationTest.php
@@ -23,25 +23,24 @@ class Http01VerificationTest extends AsyncTestCase
     /**
      * @test
      */
-    public function ignoresWrongPeerName(): \Generator
+    public function ignoresWrongPeerName(): void
     {
         self::markTestSkipped('Currently skipped as configuration is not in place for it.');
 
-        /** @var Response $payloadResponse */
-        $payloadResponse = yield HttpClientBuilder::buildDefault()->request('http://blog.kelunik.com/robots.txt');
+        $payloadResponse = HttpClientBuilder::buildDefault()->request('http://blog.kelunik.com/robots.txt');
         $payload = \trim($payloadResponse->getBody());
 
-        yield $this->verifier->verifyChallenge('kelunik.com', 'invalid-common-name', $payload);
+        $this->verifier->verifyChallenge('kelunik.com', 'invalid-common-name', $payload);
     }
 
     /**
      * @test
      */
-    public function failsOnWrongPayload(): \Generator
+    public function failsOnWrongPayload(): void
     {
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage('Verification failed');
 
-        yield $this->verifier->verifyChallenge('kelunik.com', 'abcdef', 'foobar');
+        $this->verifier->verifyChallenge('kelunik.com', 'abcdef', 'foobar');
     }
 }

--- a/test/OpensslCsrGeneratorTest.php
+++ b/test/OpensslCsrGeneratorTest.php
@@ -38,39 +38,39 @@ class OpensslCsrGeneratorTest extends AsyncTestCase
     /**
      * @test
      */
-    public function failsWithInvalidKey(): \Generator
+    public function failsWithInvalidKey(): void
     {
         $this->expectException(AcmeException::class);
 
-        yield $this->csrGenerator->generateCsr(new PrivateKey('foo'), ['example.com']);
+        $this->csrGenerator->generateCsr(new PrivateKey('foo'), ['example.com']);
     }
 
     /**
      * @test
      */
-    public function failsWithNoDomains(): \Generator
+    public function failsWithNoDomains(): void
     {
         $this->expectException(AcmeException::class);
 
-        yield $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), []);
+        $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), []);
     }
 
     /**
      * @test
      */
-    public function failsWithInvalidDomain(): \Generator
+    public function failsWithInvalidDomain(): void
     {
         $this->expectException(AcmeException::class);
 
-        yield $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), ['foo,bar']);
+        $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), ['foo,bar']);
     }
 
     /**
      * @test
      */
-    public function succeedsOtherwise(): \Generator
+    public function succeedsOtherwise(): void
     {
-        $csr = yield $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), ['example.com']);
+        $csr = $this->csrGenerator->generateCsr($this->keyGenerator->generateKey(), ['example.com']);
         $this->assertIsString($csr);
     }
 }


### PR DESCRIPTION
Updates the library to use AMP v3 instead of v2.  Should go on a v2 branch or similarly named.

Right now the following tests fail when run as part of the test suite, but pass when run individually (might be some kind of race condition?):
- ConnectTest::testCryptoConnect
- Http01VerificationTest::failsOnWrongPayload