### PR TITLE
Update to stable amphp/dns v2.0.0

### DIFF
--- a/src/Verifiers/Dns01.php
+++ b/src/Verifiers/Dns01.php
@@ -19,17 +19,17 @@ use Kelunik\Acme\AcmeException;
  */
 final class Dns01
 {
-    /** @var Dns\Resolver */
+    /** @var Dns\DnsResolver */
     private $resolver;
 
     /**
      * Dns01 constructor.
      *
-     * @param Dns\Resolver|null $resolver DNS resolver, otherwise a default resolver will be used.
+     * @param Dns\DnsResolver|null $resolver DNS resolver, otherwise a default resolver will be used.
      */
-    public function __construct(Dns\Resolver $resolver = null)
+    public function __construct(Dns\DnsResolver $resolver = null)
     {
-        $this->resolver = $resolver ?? Dns\resolver();
+        $this->resolver = $resolver ?? Dns\dnsResolver();
     }
 
     /**
@@ -49,13 +49,13 @@ final class Dns01
         $uri = '_acme-challenge.' . $domain;
 
         try {
-            $dnsRecords = $this->resolver->query($uri, Dns\Record::TXT);
-        } catch (Dns\NoRecordException $e) {
-            throw new AcmeException("Verification failed, no TXT record found for '{$uri}'.", 0, $e);
+            $dnsRecords = $this->resolver->query($uri, Dns\DnsRecord::TXT);
+        } catch (Dns\MissingDnsRecordException $e) {
+            throw new AcmeException("Verification failed, no TXT record found for '{$uri}'.", "0", $e);
         } catch (Dns\DnsException $e) {
             throw new AcmeException(
                 "Verification failed, couldn't query TXT record of '{$uri}': " . $e->getMessage(),
-                0,
+                "0",
                 $e
             );
         }

--- a/src/Verifiers/Dns01.php
+++ b/src/Verifiers/Dns01.php
@@ -51,11 +51,11 @@ final class Dns01
         try {
             $dnsRecords = $this->resolver->query($uri, Dns\DnsRecord::TXT);
         } catch (Dns\MissingDnsRecordException $e) {
-            throw new AcmeException("Verification failed, no TXT record found for '{$uri}'.", "0", $e);
+            throw new AcmeException("Verification failed, no TXT record found for '{$uri}'.", (string) ($e->getCode() ?? 404), $e);
         } catch (Dns\DnsException $e) {
             throw new AcmeException(
                 "Verification failed, couldn't query TXT record of '{$uri}': " . $e->getMessage(),
-                "0",
+                (string) ($e->getCode() ?? 500),
                 $e
             );
         }

--- a/test/AcmeClientTest.php
+++ b/test/AcmeClientTest.php
@@ -4,8 +4,8 @@ namespace Kelunik\Acme;
 
 use Amp\ByteStream\ReadableBuffer;
 use Amp\Cancellation;
-use Amp\Dns\NoRecordException;
-use Amp\Dns\Resolver;
+use Amp\Dns\DnsResolver;
+use Amp\Dns\MissingDnsRecordException;
 use Amp\Http\Client\ApplicationInterceptor;
 use Amp\Http\Client\Connection\DefaultConnectionFactory;
 use Amp\Http\Client\Connection\UnlimitedConnectionPool;
@@ -19,7 +19,7 @@ use Amp\Socket\ConnectContext;
 use Kelunik\Acme\Crypto\RsaKeyGenerator;
 use ReflectionClass;
 use function Amp\Dns\createDefaultResolver;
-use function Amp\Dns\resolver;
+use function Amp\Dns\dnsResolver;
 
 class AcmeClientTest extends AsyncTestCase
 {
@@ -40,7 +40,7 @@ class AcmeClientTest extends AsyncTestCase
     {
         parent::tearDown();
 
-        resolver(createDefaultResolver());
+        dnsResolver(createDefaultResolver());
     }
 
     /**
@@ -124,10 +124,10 @@ class AcmeClientTest extends AsyncTestCase
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessageMatches('~GET request to .* failed~');
 
-        $resolver = $this->getMockBuilder(Resolver::class)->getMock();
-        $resolver->method('resolve')->willThrowException(new NoRecordException);
+        $resolver = $this->getMockBuilder(DnsResolver::class)->getMock();
+        $resolver->method('resolve')->willThrowException(new MissingDnsRecordException());
 
-        resolver($resolver);
+        dnsResolver($resolver);
 
         $client = new AcmeClient(
             \getenv('PEBBLE_HOST') . '/dir',

--- a/test/Dns01VerificationTest.php
+++ b/test/Dns01VerificationTest.php
@@ -3,9 +3,9 @@
 namespace Kelunik\Acme;
 
 use Amp\Dns\DnsException;
-use Amp\Dns\NoRecordException;
-use Amp\Dns\Record;
-use Amp\Dns\Resolver;
+use Amp\Dns\DnsRecord;
+use Amp\Dns\DnsResolver;
+use Amp\Dns\MissingDnsRecordException;
 use Amp\PHPUnit\AsyncTestCase;
 
 class Dns01VerificationTest extends AsyncTestCase
@@ -21,7 +21,7 @@ class Dns01VerificationTest extends AsyncTestCase
     {
         parent::setUp();
 
-        $this->resolver = $this->getMockBuilder(Resolver::class)->getMock();
+        $this->resolver = $this->getMockBuilder(DnsResolver::class)->getMock();
         $this->verifier = new Verifiers\Dns01($this->resolver);
     }
 
@@ -33,7 +33,7 @@ class Dns01VerificationTest extends AsyncTestCase
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage('Verification failed, no TXT record found for \'_acme-challenge.example.com\'.');
 
-        $this->resolver->method("query")->willThrowException(new NoRecordException);
+        $this->resolver->method("query")->willThrowException(new MissingDnsRecordException());
         $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
@@ -57,7 +57,7 @@ class Dns01VerificationTest extends AsyncTestCase
         $this->expectException(AcmeException::class);
         $this->expectExceptionMessage("Verification failed, please check DNS record for '_acme-challenge.example.com'.");
 
-        $this->resolver->method("query")->willReturn([new Record("xyz", Record::TXT, 300)]);
+        $this->resolver->method("query")->willReturn([new DnsRecord("xyz", DnsRecord::TXT, 300)]);
         $this->verifier->verifyChallenge("example.com", "foobar");
     }
 
@@ -68,7 +68,7 @@ class Dns01VerificationTest extends AsyncTestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $this->resolver->method("query")->willReturn([new Record("foobar", Record::TXT, 300)]);
+        $this->resolver->method("query")->willReturn([new DnsRecord("foobar", DnsRecord::TXT, 300)]);
         $this->verifier->verifyChallenge("example.com", "foobar");
     }
 


### PR DESCRIPTION
In `kelunik/acme v2.0.0-beta.1`: The class `Kelunik\Acme\Verifiers\Dns01` uses `Amp\Dns\Resolver`.
This class is renamed to `Amp\Dns\DnsResolver` in `amphp\dns v2.0.0`.

I have renamed all references of `Dns\Resolver` to `Dns\DnsResolver`. Also renamed the function `Dns\resolver()` to `Dns\dnsResolver()` and `Dns\NoRecordException` to `Dns\MissingDnsRecordException`